### PR TITLE
Fix phone number filter. noref

### DIFF
--- a/app/code/community/Hps/Securesubmit/Model/Payment.php
+++ b/app/code/community/Hps/Securesubmit/Model/Payment.php
@@ -110,7 +110,7 @@ class Hps_Securesubmit_Model_Payment extends Mage_Payment_Model_Method_Cc
         $cardHolder = new HpsCardHolderInfo(
             $billing->getData('firstname'),
             $billing->getData('lastname'),
-            preg_replace("/[^0-9,.]/", "", $billing->getTelephone()),
+            preg_replace('/[^0-9]/', '', $billing->getTelephone()),
             $billing->getData('email'),
             $address);
 


### PR DESCRIPTION
Fixes error:

exception 'SoapFault' with message 'Unable to process request.  Message failed validation.  The 'http://Hps.Exchange.PosGateway:CardHolderPhone' element is invalid - The value '903.123.1234' is invalid according to its datatype 'http://Hps.Exchange.PosGateway:phoneType' - The Pattern constraint failed.  (line#2,pos#909)'
