### PR TITLE
fix opc section transfer on payment failure

### DIFF
--- a/app/code/community/Hps/Securesubmit/Model/Payment.php
+++ b/app/code/community/Hps/Securesubmit/Model/Payment.php
@@ -529,12 +529,13 @@ class Hps_Securesubmit_Model_Payment extends Mage_Payment_Model_Method_Cc
         }
 
         // Send checkout session back to payment section to avoid double-attempt to charge single-use token
-        if ($goToPaymentSection && Mage::app()->getRequest()->getOriginalPathInfo() == '/checkout/onepage/saveOrder') {
-            Mage::getSingleton('checkout/session')->setGotoSection('payment');
+        if ($goToPaymentSection === true) {
+            Mage::log('throwing user error with Mage_Payment_Model_Info_Exception: ' . $error);
+            throw new Mage_Payment_Model_Info_Exception($error);
+        } else {
+            Mage::log('throwing user error with Mage_Core_Exception: ' . $error);
+            throw new Mage_Core_Exception($error);
         }
-
-        Mage::log('throwing user error with Mage_Core_Exception: ' . $error);
-        throw new Mage_Core_Exception($error);
     }
 
     /**


### PR DESCRIPTION
also steps around issue when token lookup error happens with a supt being used more than once