### PR TITLE
Add transaction grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-
+.basedir
 app/design/frontend/base/default/template/securesubmit.zip
 app/design/frontend/base/default/template/securesubmit/hps-styles.css

--- a/app/code/community/Hps/Securesubmit/Block/Adminhtml/Transaction.php
+++ b/app/code/community/Hps/Securesubmit/Block/Adminhtml/Transaction.php
@@ -1,0 +1,55 @@
+<?php
+
+class Hps_Securesubmit_Block_Adminhtml_Transaction extends Mage_Adminhtml_Block_Widget_Container
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setTemplate('securesubmit/transaction.phtml');
+        $this->_controller = 'adminhtml_transaction';
+        $this->_headerText = Mage::helper('hps_securesubmit')->__('Heartland Transaction Search');
+    }
+
+    /**
+     * Prepare grid
+     *
+     * @return Mage_Adminhtml_Block_Widget_Container
+     */
+    protected function _prepareLayout()
+    {
+        $this->setChild('grid', $this->getLayout()->createBlock('hps_securesubmit/adminhtml_transaction_grid', 'securesubmit.transactions.grid'));
+        return parent::_prepareLayout();
+    }
+
+    /**
+     * Check whether it is single store mode
+     *
+     * @return bool
+     */
+    public function isSingleStoreMode()
+    {
+        return !! Mage::app()->isSingleStoreMode();
+    }
+
+    /**
+     * Retrieve grid HTML
+     *
+     * @return string
+     */
+    public function getGridHtml()
+    {
+        if ( ! Mage::helper('hps_securesubmit')->hasApiCredentials($this->_getStore())) {
+            return '';
+        }
+        return $this->getChildHtml('grid');
+    }
+
+    /**
+     * @return Mage_Core_Model_Store
+     */
+    protected function _getStore()
+    {
+        $storeId = (int) $this->getRequest()->getParam('store', Mage_Core_Model_App::ADMIN_STORE_ID);
+        return Mage::app()->getStore($storeId);
+    }
+}

--- a/app/code/community/Hps/Securesubmit/Block/Adminhtml/Transaction/Grid.php
+++ b/app/code/community/Hps/Securesubmit/Block/Adminhtml/Transaction/Grid.php
@@ -1,0 +1,186 @@
+<?php
+
+class Hps_Securesubmit_Block_Adminhtml_Transaction_Grid extends Mage_Adminhtml_Block_Widget_Grid
+{
+    /** @var string */
+    protected $_refreshTransactionsCacheFlag = 'refresh_transactions_cache';
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setId('securesubmit_transaction_grid');
+        $this->setUseAjax(TRUE);
+        $this->setDefaultDir('DESC');
+        $this->setDefaultSort('transaction_date');
+        $this->setSaveParametersInSession(TRUE);
+    }
+
+    /**
+     * Prepare additional JavaScript
+     *
+     * @return string
+     */
+    public function getAdditionalJavaScript()
+    {
+        $js = "
+            {$this->getJsObjectName()}.doFilterCallback = function() {
+                this.addVarToUrl('{$this->_refreshTransactionsCacheFlag}', 1);
+                return true;
+            };
+            {$this->getJsObjectName()}.initCallback = function() {
+                this.addVarToUrl('{$this->_refreshTransactionsCacheFlag}', '');
+                return true;
+            };
+        ";
+        return $js;
+    }
+
+    /**
+     * @return Mage_Core_Model_Store
+     */
+    protected function _getStore()
+    {
+        $storeId = (int) $this->getRequest()->getParam('store', Mage_Core_Model_App::ADMIN_STORE_ID);
+        return Mage::app()->getStore($storeId);
+    }
+
+    protected function _prepareCollection()
+    {
+        $store = $this->_getStore();
+        $collection = Mage::getResourceModel('hps_securesubmit/transaction_collection');
+        $collection->setStoreId($store->getId());
+        if ($this->getRequest()->getParam($this->_refreshTransactionsCacheFlag, FALSE)) {
+            $collection->getConnector()->refreshCache(TRUE);
+        }
+        $this->setCollection($collection);
+        try {
+            parent::_prepareCollection();
+        } catch (Exception $e) {
+            Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
+        }
+        return $this;
+    }
+
+    protected function _prepareColumns()
+    {
+        $this->addColumn('transaction_date', array(
+            'header'    => $this->__('Transaction Date'),
+            'index'     => 'transaction_date',
+            'type'      => 'datetime',
+            'width'     => '100px',
+        ));
+
+        $this->addColumn('auth_code', array(
+            'header'    => $this->__('Authorization Code'),
+            'type'      => 'text',
+            'index'     => 'auth_code',
+            'width'     => '100px',
+        ));
+
+        $this->addColumn('first_name', array(
+            'header'    => $this->__('First Name'),
+            'type'      => 'text',
+            'index'     => 'first_name',
+            'width'     => '150px',
+        ));
+
+        $this->addColumn('last_name', array(
+            'header'    => $this->__('Last Name'),
+            'type'      => 'text',
+            'index'     => 'last_name',
+            'width'     => '150px',
+        ));
+
+        $this->addColumn('cc_number', array(
+            'header'    => $this->__('CC Number'),
+            'type'      => 'text',
+            'index'     => 'cc_number',
+            'width'     => '100px',
+        ));
+
+        $this->addColumn('invoice_number', array(
+            'header'    => $this->__('Invoice Number'),
+            'type'      => 'text',
+            'index'     => 'invoice_number',
+            'width'     => '100px',
+        ));
+
+        $this->addColumn('customer_id', array(
+            'header'    => $this->__('Customer ID'),
+            'type'      => 'text',
+            'index'     => 'customer_id',
+            'width'     => '100px',
+        ));
+
+        $this->addColumn('transaction_type', array(
+            'header'    => $this->__('Transaction Type'),
+            'index'     => 'transaction_type',
+            'type'      => 'options',
+            'width'     => '100px',
+            'options'   => Mage::getSingleton('hps_securesubmit/transaction_config')->getServiceNameTypeOptions(),
+        ));
+
+        $this->addColumn('card_type', array(
+            'header'    => $this->__('Card Type'),
+            'index'     => 'card_type',
+            'type'      => 'options',
+            'width'     => '100px',
+            'options'   => Mage::getSingleton('hps_securesubmit/transaction_config')->getCardTypeOptions(),
+        ));
+
+        $this->addColumn('issuer_result', array(
+            'header'    => $this->__('Issuer Result'),
+            'type'      => 'text',
+            'index'     => 'issuer_result',
+            'width'     => '100px',
+        ));
+
+        $this->addColumn('gateway_status', array(
+            'header'    => $this->__('Status'),
+            'type'      => 'text',
+            'index'     => 'gateway_status',
+            'width'     => '100px',
+            'sortable'  => FALSE,
+            'filter'    => FALSE,
+        ));
+
+        $this->addColumn('transaction_id', array(
+            'header'    => $this->__('Transaction ID'),
+            'type'      => 'text',
+            'index'     => 'transaction_id',
+            'width'     => '100px',
+        ));
+
+        $store = $this->_getStore();
+        $this->addColumn('amount', array(
+            'header'    => $this->__('Amount'),
+            'type'      => 'currency',
+            'currency_code' => $store->getBaseCurrency()->getCode(),
+            'index'     => 'amount',
+            'filter'    => FALSE,
+        ));
+
+        $this->addColumn('description', array(
+            'header'    => $this->__('Description'),
+            'type'      => 'text',
+            'index'     => 'description',
+            'sortable'  => FALSE,
+            'filter'    => FALSE,
+        ));
+
+        $this->addExportType('*/*/exportCsv', $this->__('CSV'));
+        $this->addExportType('*/*/exportExcel', $this->__('Excel XML'));
+
+        return parent::_prepareColumns();
+    }
+
+    public function getRowUrl($row)
+    {
+        return '';
+    }
+
+    public function getGridUrl()
+    {
+        return $this->getUrl('*/*/grid', array('_current' => TRUE));
+    }
+}

--- a/app/code/community/Hps/Securesubmit/Helper/Data.php
+++ b/app/code/community/Hps/Securesubmit/Helper/Data.php
@@ -8,6 +8,8 @@
 
 class Hps_Securesubmit_Helper_Data extends Mage_Core_Helper_Abstract
 {
+    const XML_PATH_PAYMENT_HPS_SECURESUBMIT_SECRET_API_KEY  = 'payment/hps_securesubmit/secretapikey';
+    const XML_PATH_PAYMENT_HPS_SECURESUBMIT_PUBLIC_API_KEY  = 'payment/hps_securesubmit/publicapikey';
     const XML_PATH_PAYMENT_HPS_SECURESUBMIT_USE_HTTP_PROXY  = 'payment/hps_securesubmit/use_http_proxy';
     const XML_PATH_PAYMENT_HPS_SECURESUBMIT_HTTP_PROXY_HOST = 'payment/hps_securesubmit/http_proxy_host';
     const XML_PATH_PAYMENT_HPS_SECURESUBMIT_HTTP_PROXY_PORT = 'payment/hps_securesubmit/http_proxy_port';
@@ -60,5 +62,36 @@ class Hps_Securesubmit_Helper_Data extends Mage_Core_Helper_Abstract
                 Mage::throwException($e->getMessage());
             }
         }
+    }
+
+    /**
+     * Check whether the selected store has API credentials.
+     * Fallback to the default store is not used.
+     *
+     * @param mixed $storeId
+     * @return bool
+     */
+    public function hasApiCredentials($storeId = NULL)
+    {
+        if ($storeId instanceof Mage_Core_Model_Store) {
+            $storeId = (int) $storeId->getId();
+        } elseif ($storeId === NULL) {
+            $storeId = Mage_Core_Model_App::ADMIN_STORE_ID;
+        } else {
+            $storeId = (int) $storeId;
+        }
+
+        $defaultPublicApiKey = (string) Mage::getStoreConfig(self::XML_PATH_PAYMENT_HPS_SECURESUBMIT_PUBLIC_API_KEY, Mage_Core_Model_App::ADMIN_STORE_ID);
+        $defaultSecretApiKey = (string) Mage::getStoreConfig(self::XML_PATH_PAYMENT_HPS_SECURESUBMIT_SECRET_API_KEY, Mage_Core_Model_App::ADMIN_STORE_ID);
+        if ($storeId === Mage_Core_Model_App::ADMIN_STORE_ID) {
+            return ( ! empty($defaultPublicApiKey) && ! empty($defaultSecretApiKey));
+        }
+
+        $storePublicApiKey = (string) Mage::getStoreConfig(self::XML_PATH_PAYMENT_HPS_SECURESUBMIT_PUBLIC_API_KEY, $storeId);
+        $storeSecretApiKey = (string) Mage::getStoreConfig(self::XML_PATH_PAYMENT_HPS_SECURESUBMIT_SECRET_API_KEY, $storeId);
+        $hasPublicKey = ( ! empty($storePublicApiKey) && $storePublicApiKey !== $defaultPublicApiKey);
+        $hasSecretKey = ( ! empty($storeSecretApiKey) && $storeSecretApiKey !== $defaultSecretApiKey);
+
+        return ($hasPublicKey && $hasSecretKey);
     }
 }

--- a/app/code/community/Hps/Securesubmit/Model/Resource/Transaction.php
+++ b/app/code/community/Hps/Securesubmit/Model/Resource/Transaction.php
@@ -1,0 +1,9 @@
+<?php
+
+class Hps_Securesubmit_Model_Resource_Transaction extends Mage_Core_Model_Resource_Db_Abstract
+{
+    protected function _construct()
+    {
+        $this->_init('hps_securesubmit/transaction', 'id');
+    }
+}

--- a/app/code/community/Hps/Securesubmit/Model/Resource/Transaction/Collection.php
+++ b/app/code/community/Hps/Securesubmit/Model/Resource/Transaction/Collection.php
@@ -1,0 +1,251 @@
+<?php
+
+class Hps_Securesubmit_Model_Resource_Transaction_Collection extends Varien_Data_Collection
+{
+    /** @var Hps_Securesubmit_Model_Payment */
+    protected $_connector;
+
+    /** @var array */
+    protected $_data = NULL;
+
+    /** @var string */
+    protected $_dateFormat = 'Y-m-d\TH:i:s.00\Z';
+
+    /** @var string */
+    protected $_timezone = 'UTC';
+
+    /** @var int */
+    protected $_priorDays = 30;
+
+    /** @var int */
+    protected $_maxPriorDays = 60;
+
+    /** @var int */
+    protected $_storeId = NULL;
+
+    protected $_filtersMapping = array(
+        'auth_code'         => 'AuthCode',
+        'first_name'        => 'CardHolderFirstName',
+        'last_name'         => 'CardHolderLastName',
+        'invoice_number'    => 'InvoiceNbr',
+        'customer_id'       => 'CustomerID',
+        'transaction_type'  => 'ServiceName',
+        'card_type'         => 'CardType',
+        'issuer_result'     => 'IssuerResult',
+        'transaction_id'    => 'TxnId',
+    );
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->_connector = Mage::getSingleton('hps_securesubmit/transaction_query');
+    }
+
+    /**
+     * @return Hps_Securesubmit_Model_Transaction_Query
+     */
+    public function getConnector()
+    {
+        return $this->_connector;
+    }
+
+    /**
+     * Set store id
+     *
+     * @param int $storeId
+     * @return Hps_Securesubmit_Model_Resource_Transaction_Collection
+     */
+    public function setStoreId($storeId)
+    {
+        $this->_storeId = (int) $storeId;
+        return $this;
+    }
+
+    /**
+     * Add search criteria.
+     *
+     * @param mixed $field
+     * @param mixed $condition
+     * @return Hps_Securesubmit_Model_Resource_Transaction_Collection
+     */
+    public function addFieldToFilter($field, $condition = NULL)
+    {
+        $this->_addQueryFilter($field, $condition);
+        return $this;
+    }
+
+    /**
+     * Load data
+     *
+     * @param bool $printQuery
+     * @param bool $logQuery
+     * @return  Hps_Securesubmit_Model_Resource_Transaction_Collection
+     */
+    public function load($printQuery = false, $logQuery = false)
+    {
+        if ($this->isLoaded()) {
+            return $this;
+        }
+
+        $data = $this->getData();
+        $this->resetData();
+
+        if (is_array($data)) {
+            foreach ($data as $row) {
+                $item = $this->getNewEmptyItem();
+                $item->addData($row);
+                $this->addItem($item);
+            }
+        }
+
+        $this->_setIsLoaded();
+        return $this;
+    }
+
+    /**
+     * Get all data array for collection
+     *
+     * @return array
+     */
+    public function getData()
+    {
+        if ($this->_data === NULL) {
+            $data = $this->getConnector()->findTransactions($this->_storeId);
+
+            // Apply sort criteria and direction
+            $order = array_slice($this->_orders, 0, 1);
+            $criteria = key($order);
+            $direction = array_shift($order);
+            if ($criteria && $direction) {
+                $sort = array();
+                foreach ($data as $key => $row) {
+                    $sort[$key] = $row[$criteria];
+                }
+                array_multisort($sort, ($direction == 'ASC') ? SORT_ASC : SORT_DESC, $data);
+            }
+
+            // Apply pagination
+            $currentPage = array();
+            $startIndex = ($this->getCurPage() - 1) * $this->getPageSize();
+            $endIndex = min($startIndex + $this->getPageSize() - 1, $this->getSize() - 1);
+            $index = $startIndex;
+            while ($index <= $endIndex) {
+                $currentPage[] = $data[$index];
+                $index ++;
+            }
+
+            $this->_data = $currentPage;
+        }
+        return $this->_data;
+    }
+
+    /**
+     * Reset loaded for collection data array
+     *
+     * @return Hps_Securesubmit_Model_Resource_Transaction_Collection
+     */
+    public function resetData()
+    {
+        $this->_data = NULL;
+        return $this;
+    }
+
+    /**
+     * Retrieve collection all items count.
+     * API does not provide functionality to retrieve count of transactions.
+     *
+     * @return int
+     */
+    public function getSize()
+    {
+        return $this->getConnector()->getAmount();
+    }
+
+    /**
+     * Prepare query filter
+     *
+     * @param mixed $field
+     * @param mixed $condition
+     * @throws Mage_Core_Exception
+     * @return Hps_Securesubmit_Model_Resource_Transaction_Collection
+     */
+    protected function _addQueryFilter($field, $condition)
+    {
+        // Process transaction date filter. Both "StartUtcDT" and "EndUtcDT" are required!
+        if ($field == 'transaction_date' && (isset($condition['from']) || $condition['to'])) {
+            // "From" date
+            if (isset($condition['from']) && ($condition['from'] instanceof Zend_Date)) {
+                $fromDate = $condition['from']; /** @var $fromDate Zend_Date */
+                $currentDate = new Zend_Date(Mage::getSingleton('core/date')->gmtDate('Y-m-d'));
+                $earliestDate = clone $currentDate;
+                $earliestDate->subDay($this->_maxPriorDays);
+                if ($fromDate->isEarlier($earliestDate)) {
+                    $fromDate = $earliestDate;
+                }
+                $this->getConnector()->addFilter('StartUtcDT', $this->_formatDate($fromDate));
+            } else {
+                $from = new Zend_Date(Mage::getSingleton('core/date')->gmtDate('Y-m-d'));
+                $from->subDay($this->_priorDays);
+                $this->getConnector()->addFilter('StartUtcDT', $this->_formatDate($from));
+            }
+
+            // "To" date
+            if (isset($condition['to']) && ($condition['to'] instanceof Zend_Date)) {
+                $this->getConnector()->addFilter('EndUtcDT', $this->_formatDate($condition['to']));
+            } else {
+                $this->getConnector()->addFilter('EndUtcDT', $this->_formatDate());
+            }
+        } else {
+            // Prepare condition
+            if (isset($condition['like'])) {
+                $convertedCondition = str_replace('\_', '_', (string) $condition['like']); // unescape SQL syntax
+                $convertedCondition = str_replace("'", '', (string) $convertedCondition);
+                $convertedCondition = trim($convertedCondition, '%');
+            } else if (isset($condition['eq'])) {
+                $convertedCondition = (string) $condition['eq'];
+            } else {
+                $convertedCondition = (string) $condition;
+            }
+
+            // Process credit card filter
+            if ($field == 'cc_number') {
+                if (strlen($convertedCondition) === 6) {
+                    $this->getConnector()->addFilter('CardNbrFirstSix', $convertedCondition);
+                } else {
+                    $this->getConnector()->addFilter('CardNbrLastFour', $convertedCondition);
+                }
+            }
+            // Issuer result field is the code only and supports range check
+            else if ($field == 'issuer_result') {
+                if ( ! preg_match('/^[0-9EN][0-9BC](-[0-9EN][0-9BC])?$/', trim($convertedCondition, '%'))) {
+                    throw new Mage_Core_Exception('Issuer result query must be the two-digit code (00) or a range of codes (00-05).');
+                }
+                $this->getConnector()->addFilter('IssuerResult', trim($convertedCondition, '%'));
+            }
+            // Process other fields
+            else if (isset($this->_filtersMapping[$field])) {
+                $this->getConnector()->addFilter($this->_filtersMapping[$field], $convertedCondition);
+            }
+        }
+    }
+
+    /**
+     * Format date to internal API format
+     *
+     * @param Zend_Date|string|null $date
+     * @return string
+     */
+    protected function _formatDate($date = NULL)
+    {
+        if ($date === NULL) {
+            $date = Mage::getSingleton('core/date')->gmtDate('Y-m-d');
+        } else if ($date instanceof Zend_Date) {
+            $date = $date->toString();
+        }
+        $dateTime = new DateTime($date, new DateTimeZone($this->_timezone));
+        return $dateTime->format($this->_dateFormat);
+    }
+}

--- a/app/code/community/Hps/Securesubmit/Model/Transaction.php
+++ b/app/code/community/Hps/Securesubmit/Model/Transaction.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @method Hps_Securesubmit_Model_Resource_Transaction getResource()
+ */
+class Hps_Securesubmit_Model_Transaction extends Mage_Core_Model_Abstract
+{
+    protected function _construct()
+    {
+        $this->_init('hps_securesubmit/transaction');
+    }
+}

--- a/app/code/community/Hps/Securesubmit/Model/Transaction/Config.php
+++ b/app/code/community/Hps/Securesubmit/Model/Transaction/Config.php
@@ -1,0 +1,65 @@
+<?php
+
+class Hps_Securesubmit_Model_Transaction_Config
+{
+    /**
+     * Retrieve card type options
+     *
+     * @return array
+     */
+    public function getCardTypeOptions()
+    {
+        static $options;
+        if ( ! $options) {
+            $options = array(
+                'VISA'      => 'VISA',
+                'MC'        => 'MC',
+                'DISC'      => 'DISC',
+                'AMEX'      => 'AMEX',
+                'GIFTCARD'  => 'GIFTCARD',
+            );
+        }
+        return $options;
+    }
+
+    /**
+     * Retrieve service name type options
+     *
+     * @return array
+     */
+    public function getServiceNameTypeOptions()
+    {
+        static $options;
+        if ( ! $options) {
+            $options = array(
+                'DebitSale'                 => 'DebitSale',
+                'DebitReturn'               => 'DebitReturn',
+                'CreditOfflineSale'         => 'CreditOfflineSale',
+                'CreditOfflineAuth'         => 'CreditOfflineAuth',
+                'CreditReturn'              => 'CreditReturn',
+                'CreditReversal'            => 'CreditReversal',
+                'CreditAuth'                => 'CreditAuth',
+                'CreditSale'                => 'CreditSale',
+                'CreditVoid'                => 'CreditVoid',
+                'CheckSale'                 => 'CheckSale',
+                'CheckVoid'                 => 'CheckVoid',
+                'GiftCardActivate'          => 'GiftCardActivate',
+                'GiftCardAddValue'          => 'GiftCardAddValue',
+                'GiftCardReplace'           => 'GiftCardReplace',
+                'GiftCardReward'            => 'GiftCardReward',
+                'GiftCardSale'              => 'GiftCardSale',
+                'GiftCardTip'               => 'GiftCardTip',
+                'GiftCardReversal'          => 'GiftCardReversal',
+                'GiftCardVoid'              => 'GiftCardVoid',
+                'EBTFSPurchase'             => 'EBTFSPurchase',
+                'EBTFSReturn'               => 'EBTFSReturn',
+                'EBTVoucherPurchase'        => 'EBTVoucherPurchase',
+                'EBTCashBackPurchase'       => 'EBTCashBackPurchase',
+                'EBTCashBenefitWithdrawal'  => 'EBTCashBenefitWithdrawal',
+                'PrePaidAddValue'           => 'PrePaidAddValue',
+                'ReCurringBilling'          => 'ReCurringBilling',
+            );
+        }
+        return $options;
+    }
+}

--- a/app/code/community/Hps/Securesubmit/Model/Transaction/Query.php
+++ b/app/code/community/Hps/Securesubmit/Model/Transaction/Query.php
@@ -1,0 +1,203 @@
+<?php
+
+class Hps_Securesubmit_Model_Transaction_Query extends Mage_Core_Model_Abstract
+{
+    const PROFILER_PREFIX = 'HPS SecureSubmit Transactions : ';
+    const CACHE_PREFIX = 'HPS_SECURESUBMIT_TRANSACTIONS';
+    const CACHE_TYPE = 'securesubmit_transactions';
+    const CACHE_TAG = 'securesubmit_transactions';
+
+    /**
+     * Refresh cache flag
+     *
+     * @var bool
+     */
+    protected $_refreshCache = FALSE;
+
+    /**
+     * List of filters
+     *
+     * @var array
+     */
+    protected $_filters = array();
+
+    /**
+     * Amount of found transactions
+     *
+     * @var int
+     */
+    protected $_amount = 0;
+
+    /**
+     * List of error messages
+     *
+     * @var array
+     */
+    protected $_errorMessages = array();
+
+    /**
+     * Find transactions
+     *
+     * @param int $storeId
+     * @return array
+     */
+    public function findTransactions($storeId = NULL)
+    {
+        try {
+            $transactions = $this->_findTransactions($storeId);
+            $this->_amount = count($transactions);
+        } catch (Exception $e) {
+            $this->addErrorMessage($e->getMessage());
+            $transactions = array();
+            $this->_amount = 0;
+        }
+
+        return $transactions;
+    }
+
+    /**
+     * Check whether need to refresh transactions grid cache
+     *
+     * @param bool $refresh
+     * @return bool
+     */
+    public function refreshCache($refresh = NULL)
+    {
+        $result = $this->_refreshCache;
+        if ( ! is_null($refresh)) {
+            $this->_refreshCache = $refresh;
+        }
+        return $result;
+    }
+
+    /**
+     * Add filter
+     *
+     * @param string $field
+     * @param string $condition
+     * @return Hps_Securesubmit_Model_Transaction_Query
+     */
+    public function addFilter($field, $condition)
+    {
+        $this->_filters[$field] = $condition;
+    }
+
+    /**
+     * Add error message
+     *
+     * @param string $message
+     * @return Hps_Securesubmit_Model_Transaction_Query
+     */
+    public function addErrorMessage($message)
+    {
+        $this->_errorMessages[] = $message;
+        return $this;
+    }
+
+    /**
+     * Retrieve error messages
+     *
+     * @return array
+     */
+    public function getErrorMessages()
+    {
+        return $this->_errorMessages;
+    }
+
+    /**
+     * Amount of found emails according to filters
+     *
+     * @return int
+     */
+    public function getAmount()
+    {
+        if ($this->_amount === NULL) {
+            $this->_amount = count($this->findTransactions());
+        }
+        return (int) $this->_amount;
+    }
+
+    /**
+     * Find transactions
+     *
+     * @param int $storeId
+     * @return array
+     */
+    protected function _findTransactions($storeId = NULL)
+    {
+        // Get transactions from cache
+        $searchCacheKey = $this->_getCacheKey('transactions_list', $storeId) . md5(serialize($this->_filters));
+        if ( ! $this->refreshCache(FALSE) && $this->_useCache() && $cache = Mage::app()->loadCache($searchCacheKey)) {
+            $transactions = unserialize($cache);
+
+        } // Perform search
+        else {
+            $paymentModel = Mage::getSingleton('hps_securesubmit/payment'); /* @var $paymentModel Hps_Securesubmit_Model_Payment */
+            $response = $paymentModel->setStore($storeId)->findTransactions($this->_filters);
+            $exceptionMapper = new HpsExceptionMapper();
+            $transactions = array();
+            foreach ($response as $object) { /** @var $object HpsFindTransactionsTransactionDetails */
+                $transaction = array();
+
+                $transaction['first_name'] = $transaction['last_name'] = NULL;
+                if ($object->cardHolderData instanceof HpsCardHolder) {
+                    $transaction['first_name'] = (string) $object->cardHolderData->firstName;
+                    $transaction['last_name'] = (string) $object->cardHolderData->lastName;
+                }
+
+                $transaction['invoice_number'] = $transaction['customer_id'] = NULL;
+                if ($object->additionalTxnFields instanceof HpsAdditionalTxnFieldsData) {
+                    $transaction['description'] = (string) $object->additionalTxnFields->description;
+                    $transaction['invoice_number'] = (string) $object->additionalTxnFields->invoiceNumber;
+                    $transaction['customer_id'] = (string) $object->additionalTxnFields->customerId;
+                }
+
+                $transaction['transaction_date'] = (string) $object->responseDatetime;
+                $transaction['auth_code'] = (string) $object->authorizationCode;
+                $transaction['cc_number'] = (string) $object->maskedCardNumber;
+                $transaction['transaction_type'] = (string) $object->serviceName;
+                $transaction['card_type'] = (string) strtoupper($object->cardType);
+                $transaction['gateway_status'] = (string) $object->responseText;
+                $transaction['transaction_id'] = (int) $object->transactionId;
+                $transaction['amount'] = (float) $object->amount;
+
+                $issuerResult = '00 Approval';
+                if ($object->issuerResponseCode != '00') {
+                    $exception = $exceptionMapper->map_issuer_exception($object->transactionId, $object->issuerResponseCode, $object->issuerResponseText);
+                    $issuerResult = $object->issuerResponseCode.' '.$exception->getMessage();
+                }
+                $transaction['issuer_result'] = $issuerResult;
+                $transactions[] = $transaction;
+            }
+
+            // Save search results in cache
+            if ($this->_useCache()) {
+                Mage::app()->saveCache(serialize($transactions), $searchCacheKey, array('COLLECTION_DATA', self::CACHE_TAG), 60 * 5);
+            }
+        }
+
+        return $transactions;
+    }
+
+    /**
+     * Cache key wrapper
+     *
+     * @param string $key
+     * @param null|int $storeId
+     * @return string
+     */
+    protected function _getCacheKey($key, $storeId = NULL)
+    {
+        return self::CACHE_PREFIX . '_' . md5($key) . '_STORE_' . $storeId;
+    }
+
+    /**
+     * Check whether email archive cache is enabled
+     *
+     * @return bool
+     */
+    protected function _useCache()
+    {
+        return (bool) Mage::app()->useCache(self::CACHE_TYPE);
+    }
+}

--- a/app/code/community/Hps/Securesubmit/controllers/Adminhtml/Securesubmit/TransactionController.php
+++ b/app/code/community/Hps/Securesubmit/controllers/Adminhtml/Securesubmit/TransactionController.php
@@ -1,0 +1,62 @@
+<?php
+
+class Hps_Securesubmit_Adminhtml_Securesubmit_TransactionController extends Mage_Adminhtml_Controller_Action
+{
+    /**
+     * Transactions grid action
+     */
+    public function indexAction()
+    {
+        if ( ! Mage::helper('hps_securesubmit')->hasApiCredentials($this->_getStore())) {
+            $this->_getSession()->addNotice(Mage::helper('hps_securesubmit')->__('SecureSubmit is not configured for the selected store scope.'));
+        }
+        $this->loadLayout();
+        $this->renderLayout();
+    }
+
+    /**
+     * Transactions grid action
+     */
+    public function gridAction()
+    {
+        $this->loadLayout(FALSE);
+        $this->renderLayout();
+    }
+
+    /**
+     * Export transactions grid to CSV format
+     */
+    public function exportCsvAction()
+    {
+        $fileName   = 'hps_transactions.csv';
+        $grid       = $this->getLayout()->createBlock('hps_securesubmit/adminhtml_transaction_grid');
+        $this->_prepareDownloadResponse($fileName, $grid->getCsvFile());
+    }
+
+    /**
+     *  Export transactions grid to Excel XML format
+     */
+    public function exportExcelAction()
+    {
+        $fileName   = 'hps_transactions.xml';
+        $grid       = $this->getLayout()->createBlock('hps_securesubmit/adminhtml_transaction_grid');
+        $this->_prepareDownloadResponse($fileName, $grid->getExcelFile($fileName));
+    }
+
+    /**
+     * @return Mage_Core_Model_Store
+     */
+    protected function _getStore()
+    {
+        $storeId = (int) $this->getRequest()->getParam('store', Mage_Core_Model_App::ADMIN_STORE_ID);
+        return Mage::app()->getStore($storeId);
+    }
+
+    /**
+     * @return bool
+     */
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('sales/transactions/heartland_transaction_search');
+    }
+}

--- a/app/code/community/Hps/Securesubmit/etc/adminhtml.xml
+++ b/app/code/community/Hps/Securesubmit/etc/adminhtml.xml
@@ -1,5 +1,20 @@
 <?xml version="1.0"?>
 <config>
+    <menu>
+        <sales>
+            <children>
+                <transactions>
+                    <children>
+                        <heartland_transaction_search translate="title" module="hps_securesubmit">
+                            <title>Heartland Transaction Search</title>
+                            <action>adminhtml/securesubmit_transaction/index</action>
+                            <sort_order>10</sort_order>
+                        </heartland_transaction_search>
+                    </children>
+                </transactions>
+            </children>
+        </sales>
+    </menu>
     <acl>
         <resources>
             <admin>
@@ -20,6 +35,14 @@
                             </order>
                         </children>
                     </sales>
+                    <transactions>
+                        <children>
+                            <heartland_transaction_search translate="title" module="hps_securesubmit">
+                                <title>Heartland Transaction Search</title>
+                                <sort_order>10</sort_order>
+                            </heartland_transaction_search>
+                        </children>
+                    </transactions>
                     <report>
                         <children>
                             <salesroot>

--- a/app/design/adminhtml/default/default/layout/securesubmit.xml
+++ b/app/design/adminhtml/default/default/layout/securesubmit.xml
@@ -10,4 +10,19 @@
             </action>
         </reference>
     </adminhtml_sales_order_create_index>
+
+	<adminhtml_securesubmit_transaction_index>
+        <reference name="content">
+            <block type="hps_securesubmit/adminhtml_transaction" name="securesubmit.transactions.grid.container">
+                <block type="adminhtml/store_switcher" name="store_switcher" as="store_switcher">
+                    <action method="setUseConfirm"><params>0</params></action>
+                </block>
+            </block>
+        </reference>
+    </adminhtml_securesubmit_transaction_index>
+
+    <adminhtml_securesubmit_transaction_grid>
+        <update handle="formkey" />
+        <block type="hps_securesubmit/adminhtml_transaction_grid" name="securesubmit.transactions.grid" output="toHtml" />
+    </adminhtml_securesubmit_transaction_grid>
 </layout>

--- a/app/design/adminhtml/default/default/template/securesubmit/transaction.phtml
+++ b/app/design/adminhtml/default/default/template/securesubmit/transaction.phtml
@@ -1,0 +1,15 @@
+<?php /** @var $this Hps_Securesubmit_Block_Adminhtml_Transaction */ ?>
+<div class="content-header">
+    <table cellspacing="0">
+        <tr>
+            <td style="width:50%;"><h3 class="icon-head head-products"><?php echo $this->getHeaderText() ?></h3></td>
+        </tr>
+    </table>
+</div>
+<?php echo $this->getStoreSwitcherHtml() ?>
+<?php if ( ! $this->isSingleStoreMode()) : ?>
+    <?php echo $this->getChildHtml('store_switcher') ?>
+<?php endif;?>
+<div>
+    <?php echo $this->getGridHtml() ?>
+</div>


### PR DESCRIPTION
Adds Magento admin transaction grid. This allows non-HPS users to view certain transaction information from the admin panel within ACL permissions.