### PR TITLE
Shipping address check

### DIFF
--- a/app/code/community/Hps/Securesubmit/Block/Form.php
+++ b/app/code/community/Hps/Securesubmit/Block/Form.php
@@ -16,6 +16,26 @@ class Hps_SecureSubmit_Block_Form extends Mage_Payment_Block_Form_Ccsave
         $this->setTemplate('securesubmit/form.phtml');
     }
 
+    /**
+     * Check whether the customer has any saved credit card
+     *
+     * @return bool
+     */
+    public function hasAnySavedCard()
+    {
+        return (bool) Mage::helper('hps_securesubmit')->getStoredCards($this->getCustomerId())->getSize();
+    }
+
+    /**
+     * Retrieve the list of the customer's stored cards that can be applied to the current shipping address
+     *
+     * @return Hps_Securesubmit_Model_Resource_Storedcard_Collection|Hps_Securesubmit_Model_Storedcard[]
+     */
+    public function getAllowedStoredCards()
+    {
+        return Mage::helper('hps_securesubmit')->getStoredCards($this->getCustomerId(), $this->getCustomerAddressId());
+    }
+
     public function getCca()
     {
         if (!$this->getConfig('enable_threedsecure')) {

--- a/app/code/community/Hps/Securesubmit/Block/Form.php
+++ b/app/code/community/Hps/Securesubmit/Block/Form.php
@@ -81,4 +81,49 @@ class Hps_SecureSubmit_Block_Form extends Mage_Payment_Block_Form_Ccsave
     {
         return Mage::getStoreConfig(sprintf('payment/hps_securesubmit/%s', $key));
     }
+
+    /**
+     * Retrieve credit card info
+     *
+     * @param Hps_Securesubmit_Model_Storedcard $card
+     * @return string
+     */
+    public function getCCInfo(Hps_Securesubmit_Model_Storedcard $card)
+    {
+        $info = $card->getCcType().' '.str_repeat('*', 12).$card->getCcLast4().' ('.$card->getCcExpMonth().'/'.$card->getCcExpYear().')';
+        if ($card->isExpired()) {
+            $info.= ' '.$this->__('*expired');
+        }
+        return $info;
+    }
+
+    /**
+     * Check whether the customer has added a new shipping address
+     *
+     * @return bool
+     */
+    public function isNewAddress()
+    {
+        return ! $this->getCustomerAddressId();
+    }
+
+    /**
+     * Retrieve the customer address id for the shipping address
+     *
+     * @return int
+     */
+    public function getCustomerAddressId()
+    {
+        return (int) Mage::getSingleton('checkout/type_onepage')->getQuote()->getShippingAddress()->getCustomerAddressId();
+    }
+
+    /**
+     * Retrieve customer id from session
+     *
+     * @return int
+     */
+    public function getCustomerId()
+    {
+        return (int) Mage::getSingleton('customer/session')->getCustomerId();
+    }
 }

--- a/app/code/community/Hps/Securesubmit/Helper/Data.php
+++ b/app/code/community/Hps/Securesubmit/Helper/Data.php
@@ -13,13 +13,31 @@ class Hps_Securesubmit_Helper_Data extends Mage_Core_Helper_Abstract
     const XML_PATH_PAYMENT_HPS_SECURESUBMIT_HTTP_PROXY_PORT = 'payment/hps_securesubmit/http_proxy_port';
 
     /**
-     * @param $customerId
+     * Retrieve list of the stored credit cards for the customer
+     *
+     * @param int|Mage_Customer_Model_Customer $customerId
+     * @param int|Mage_Customer_Model_Address $addressId
      * @return Hps_Securesubmit_Model_Storedcard[]|Hps_Securesubmit_Model_Resource_Storedcard_Collection
      */
-    public function getStoredCards($customerId)
+    public function getStoredCards($customerId, $addressId = NULL)
     {
+        if ($customerId instanceof Mage_Customer_Model_Customer) {
+            $customerId = $customerId->getId();
+        }
+        if ($addressId instanceof Mage_Customer_Model_Address) {
+            $addressId = $addressId->getId();
+        }
+        /** @var $cardCollection Hps_Securesubmit_Model_Resource_Storedcard_Collection */
         $cardCollection = Mage::getResourceModel('hps_securesubmit/storedcard_collection')
             ->addFieldToFilter('customer_id', $customerId);
+        if (NULL !== $addressId) {
+            $cardCollection->join(
+                array('address' => 'hps_securesubmit/storedcard_address'),
+                'main_table.storedcard_id = address.storedcard_id',
+                array()
+            );
+            $cardCollection->getSelect()->where('address.customer_address_id = ?', $addressId);
+        }
         return $cardCollection;
     }
 

--- a/app/code/community/Hps/Securesubmit/Model/Observer.php
+++ b/app/code/community/Hps/Securesubmit/Model/Observer.php
@@ -1,0 +1,39 @@
+<?php
+
+class Hps_Securesubmit_Model_Observer
+{
+    /**
+     * @param Varien_Event_Observer $observer
+     */
+    public function customerAddressSaveBefore(Varien_Event_Observer $observer)
+    {
+        $customerAddress = $observer->getCustomerAddress(); /** @var $customerAddress Mage_Customer_Model_Address */
+        if ($customerAddress->getId() && $customerAddress->hasDataChanges()) {
+            /*
+             * Need to load saved customer address as in some reason in Mage_Customer_AddressController::formPostAction()
+             * instead of loading existing address, only the address id is assigned to the new object.
+             * Also, because of this, need manually check whether the address has been changed.
+             */
+            $oldAddress = Mage::getModel('customer/address')->load($customerAddress->getId());
+            foreach (array('street', 'city', 'region_id', 'postcode', 'country_id') as $field) {
+                if ($customerAddress->getData($field) != $oldAddress->getData($field)) {
+                    $customerAddress->setRemoveStoredCards(TRUE);
+                    break;
+                }
+            }
+        } else if ($customerAddress->isObjectNew()) {
+            $customerAddress->setIsNewAddress(TRUE);
+        }
+    }
+
+    /**
+     * @param Varien_Event_Observer $observer
+     */
+    public function customerAddressSaveAfter(Varien_Event_Observer $observer)
+    {
+        $customerAddress = $observer->getCustomerAddress(); /** @var $customerAddress Mage_Customer_Model_Address */
+        if ($customerAddress->getRemoveStoredCards()) {
+            Mage::helper('hps_securesubmit')->removeStoredCards($customerAddress->getId());
+        }
+    }
+}

--- a/app/code/community/Hps/Securesubmit/Model/Payment.php
+++ b/app/code/community/Hps/Securesubmit/Model/Payment.php
@@ -227,7 +227,11 @@ class Hps_Securesubmit_Model_Payment extends Mage_Payment_Model_Method_Cc
             }
 
             if ($multiToken) {
-                $this->saveMultiUseToken($response, $cardData, $customerId, $cardType);
+                if ($savedCard = $this->saveMultiUseToken($response, $cardData, $customerId, $cardType)) {
+                    Mage::helper('hps_securesubmit')->saveCardToAddress($savedCard, $payment->getOrder()->getCustomerId());
+                } else {
+                    Mage::log('Requested multi token has not been generated for the transaction # ' . $response->transactionId, Zend_Log::WARN);
+                }
             }
         } catch (HpsCreditException $e) {
             $this->updateVelocity($e);

--- a/app/code/community/Hps/Securesubmit/etc/config.xml
+++ b/app/code/community/Hps/Securesubmit/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Hps_Securesubmit>
-            <version>1.4.5</version>
+            <version>1.4.6</version>
         </Hps_Securesubmit>
     </modules>
     <global>
@@ -35,6 +35,9 @@
                     <storedcard>
                         <table>storedcard</table>
                     </storedcard>
+                    <storedcard_address>
+                        <table>storedcard_address</table>
+                    </storedcard_address>
                     <report>
                         <table>report_settlement</table>
                     </report>
@@ -58,6 +61,26 @@
                 </securesubmit_use_stored_card>
             </sales_convert_quote_payment>
         </fieldsets>
+        <events>
+            <customer_address_save_before>
+                <observers>
+                    <updated_saved_credit_cards>
+                        <type>singleton</type>
+                        <class>hps_securesubmit/observer</class>
+                        <method>customerAddressSaveBefore</method>
+                    </updated_saved_credit_cards>
+                </observers>
+            </customer_address_save_before>
+            <customer_address_save_after>
+                <observers>
+                    <updated_saved_credit_cards>
+                        <type>singleton</type>
+                        <class>hps_securesubmit/observer</class>
+                        <method>customerAddressSaveAfter</method>
+                    </updated_saved_credit_cards>
+                </observers>
+            </customer_address_save_after>
+        </events>
         <payment>
             <groups>
                 <hps_paypal>HPS PayPal</hps_paypal>

--- a/app/code/community/Hps/Securesubmit/sql/hps_securesubmit_setup/mysql4-upgrade-1.2.0-1.4.6.php
+++ b/app/code/community/Hps/Securesubmit/sql/hps_securesubmit_setup/mysql4-upgrade-1.2.0-1.4.6.php
@@ -1,0 +1,49 @@
+<?php
+/** @var $this Hps_Securesubmit_Model_Resource_Setup */
+$installer = $this;
+$installer->startSetup();
+
+/*
+ * Add "storedcard_address" table.
+ */
+$this->run("
+CREATE TABLE IF NOT EXISTS `{$this->getTable('hps_securesubmit/storedcard_address')}` (
+  `storedcard_id` int(10) unsigned NOT NULL,
+  `customer_address_id` int(10) unsigned NOT NULL,
+  UNIQUE KEY `UNQ_STORED_CARD_ID_CUSTOMER_ADDRESS_ID` (`storedcard_id`,`customer_address_id`),
+  KEY `customer_address_id` (`customer_address_id`)
+) ENGINE=InnoDB;
+");
+
+$this->getConnection()->addForeignKey(
+    $installer->getFkName('hps_securesubmit/storedcard_address', 'storedcard_id', 'hps_securesubmit/storedcard', 'storedcard_id'),
+    $installer->getTable('hps_securesubmit/storedcard_address'),
+    'storedcard_id',
+    $installer->getTable('hps_securesubmit/storedcard'),
+    'storedcard_id',
+    Varien_Db_Ddl_Table::ACTION_CASCADE,
+    Varien_Db_Ddl_Table::ACTION_CASCADE
+);
+
+$this->getConnection()->addForeignKey(
+    $installer->getFkName('hps_securesubmit/storedcard_address', 'customer_address_id', 'customer/address_entity', 'entity_id'),
+    $installer->getTable('hps_securesubmit/storedcard_address'),
+    'customer_address_id',
+    $installer->getTable('customer/address_entity'),
+    'entity_id',
+    Varien_Db_Ddl_Table::ACTION_CASCADE,
+    Varien_Db_Ddl_Table::ACTION_CASCADE
+);
+
+/**
+ * Assign existing stored cards to all existing customer's addresses.
+ */
+$select = $this->getConnection()->select()
+    ->from(
+        array('sc' => $this->getTable('hps_securesubmit/storedcard')),
+        array('storedcard_id' => 'sc.storedcard_id', 'customer_address_id' => 'cae.entity_id'))
+    ->join(array('cae' => $this->getTable('customer/address_entity')), 'sc.customer_id = cae.parent_id', array());
+$query = $select->insertIgnoreFromSelect($this->getTable('hps_securesubmit/storedcard_address'));
+$this->getConnection()->query($query);
+
+$installer->endSetup();

--- a/app/design/frontend/base/default/template/securesubmit/form.phtml
+++ b/app/design/frontend/base/default/template/securesubmit/form.phtml
@@ -9,7 +9,7 @@ $use_iframes = !!Mage::getModel('hps_securesubmit/payment')->getConfigData('use_
 $cca = $this->getCca();
 
 if ($_loggedIn && $allow_card_saving) {
-    $customerStoredCards = Mage::helper('hps_securesubmit')->getStoredCards( Mage::getSingleton('customer/session')->getCustomerId());
+    $customerStoredCards = $this->getAllowedStoredCards();
 }
 ?>
 


### PR DESCRIPTION
This addition adds a new table associating customer addresses with stored cards. The feature is strengthening of fraud prevention on the UI. If a user adds a stored card under one address, then later changes it, will need to re-enter their credit card information at checkout. In the case a user's account is compromised by a user attempting to route shipments elsewhere, this should prevent the bad actor from successfully checking out with a stored card.