### PR TITLE
Expired card interface

### DIFF
--- a/app/code/community/Hps/Securesubmit/Block/Form.php
+++ b/app/code/community/Hps/Securesubmit/Block/Form.php
@@ -61,4 +61,20 @@ class Hps_SecureSubmit_Block_Form extends Mage_Payment_Block_Form_Ccsave
     {
         return Mage::getStoreConfig(sprintf('payment/hps_securesubmit/%s', $key));
     }
+
+
+    /**
+     * Retrieve credit card info
+     *
+     * @param Hps_Securesubmit_Model_Storedcard $card
+     * @return string
+     */
+    public function getCCInfo(Hps_Securesubmit_Model_Storedcard $card)
+    {
+        $info = $card->getCcType().' '.str_repeat('*', 12).$card->getCcLast4().' ('.$card->getCcExpMonth().'/'.$card->getCcExpYear().')';
+        if ($card->isExpired()) {
+            $info.= ' '.$this->__('*expired');
+        }
+        return $info;
+    }
 }

--- a/app/code/community/Hps/Securesubmit/Model/Storedcard.php
+++ b/app/code/community/Hps/Securesubmit/Model/Storedcard.php
@@ -37,4 +37,17 @@ class Hps_Securesubmit_Model_Storedcard  extends Mage_Core_Model_Abstract
         return $this;
     }
 
+    /**
+     * Check whether the card is expired
+     *
+     * @return bool
+     */
+    public function isExpired()
+    {
+        $ccMonth = (int) $this->getCcExpMonth();
+        $ccYear = (int) $this->getCcExpYear();
+        $currentMonth = (int) Mage::app()->getLocale()->date()->toString('M');
+        $currentYear = (int) Mage::app()->getLocale()->date()->toString('Y');
+        return ($currentYear > $ccYear || ($currentYear == $ccYear && $currentMonth > $ccMonth));
+    }
 }

--- a/app/design/frontend/base/default/template/securesubmit/form.phtml
+++ b/app/design/frontend/base/default/template/securesubmit/form.phtml
@@ -30,7 +30,7 @@ if ($_loggedIn && $allow_card_saving) {
                       <div class="cc-info">
                             <input type="hidden" id="<?= $_code ?>_stored_card_select_<?= $card->getId() ?>_card_type" value="<?= $card->getCcType() ?>" />
                               <span class="cc"><?= $card->getCcType().' ************'.$card->getCcLast4()?></span><br>
-                              <span class="exp"><?= "expires on" ." "  .' (' .$card->getCcExpMonth().'/'.$card->getCcExpYear().')' ?></span>
+                              <span class="exp"><?= "expires on" ." "  .' (' .$card->getCcExpMonth().'/'.$card->getCcExpYear().')' ?><?php if ($card->isExpired()) { echo ' *expired'; } ?></span>
                       </div>
                     <div id="stored-cc-icon" class="icon-<?= strtolower($card->getCcType()) ?>-form"></div>
                   </label>

--- a/app/design/frontend/base/default/template/securesubmit/storedcards.phtml
+++ b/app/design/frontend/base/default/template/securesubmit/storedcards.phtml
@@ -1,13 +1,13 @@
 <?php
 $_storedCards = Mage::helper('hps_securesubmit')->getStoredCards(Mage::getSingleton('customer/session')->getCustomerId());
+$hasExpiredCards = false;
 ?>
 <span class="icon-ss"></span>
 <h1><?php echo $this->__('Manage Saved Cards') ?></h1>
+<?php echo $this->getMessagesBlock()->getGroupedHtml() ?>
 <div class="box-account">
     <?php if (count($_storedCards)): ?>
-
-            <h2><?php echo $this->__('Saved Credit Cards') ?></h2>
-
+        <h2><?php echo $this->__('Saved Credit Cards') ?></h2>
         <ul id="hps-saved-cards" class="saved-card-table">
             <?php foreach ($_storedCards->getData() as $card): ?>
                 <li>
@@ -21,6 +21,16 @@ $_storedCards = Mage::helper('hps_securesubmit')->getStoredCards(Mage::getSingle
                 </li>
             <?php endforeach; ?>
         </ul>
+        <?php if ($hasExpiredCards) : ?>
+            <br />
+            <ul class="messages">
+                <li class="notice-msg">
+                    <ul>
+                        <li><span><?php echo $this->__('Your previously saved card is expired. Please update your card information') ?></span></li>
+                    </ul>
+                </li>
+            </ul>
+        <?php endif; ?>
     <?php else: ?>
         <p>
             <?php echo $this->__('You do not have any saved credit cards.') ?>

--- a/js/securesubmit/checkout-form.js
+++ b/js/securesubmit/checkout-form.js
@@ -13,7 +13,11 @@ function securesubmitMultishipping(multiForm) {
                 var radio = $$('[name="hps_securesubmit_stored_card_select"]:checked')[0];
                 var storedcardId = radio.value;
                 var storedcardType = $(radio.id + '_card_type').value;
-
+                var expInfo = $$('div.cc-info > span.exp').innerHTML
+                if (expInfo.indexOf('*expired') != -1) {
+                    alert('Your previously saved card is expired. Please update your card information');
+                    return;
+                }
                 new Ajax.Request(this.secureSubmitGetTokenDataUrl, {
                     method: 'post',
                     parameters: {storedcard_id: storedcardId},


### PR DESCRIPTION
This feature adds better visibility for a customer with expired credit cards. Within the saved cards, a message is displayed along with '*expired' next to the card entry. Within checkout, this also prevents a user from using an '*expired' card before making any requests to the SecureSubmit API.