### PR TITLE
US153689 - Magento 1: Disable MasterPass

### DIFF
--- a/app/design/frontend/base/default/layout/securesubmit.xml
+++ b/app/design/frontend/base/default/layout/securesubmit.xml
@@ -68,7 +68,7 @@
             <path>securesubmit/storedcard/index</path>
             <label>Manage Cards</label>
           </action>
-          <action method="addLink">
+          <action method="addLink" translate="label" module="hps_securesubmit" ifconfig="payment/hps_masterpass/active">
             <name>masterpass_connect</name>
             <path>securesubmit/masterpass/connect</path>
             <label>MasterPass</label>


### PR DESCRIPTION
Hiding MasterPass from the Magento 1 user account menu on the left if the merchant has disabled MasterPass as a payment option