### PR TITLE
Fix broken multi-use token expiration

### DIFF
--- a/app/code/community/Hps/Securesubmit/Helper/Data.php
+++ b/app/code/community/Hps/Securesubmit/Helper/Data.php
@@ -28,7 +28,7 @@ class Hps_Securesubmit_Helper_Data extends Mage_Core_Helper_Abstract
      * @param HpsCreditCard $cardData
      * @param string        $cardType
      * @param integer|null  $customerId
-     * @return Hps_Securesubmit_Model_Storedcard
+     * @return Hps_Securesubmit_Model_Storedcard|null
      */
     public function saveMultiToken($token,$cardData,$cardType, $customerId = null)
     {
@@ -37,20 +37,18 @@ class Hps_Securesubmit_Helper_Data extends Mage_Core_Helper_Abstract
 
         if($_loggedIn || $customerId != null){
             if($customerId == null){
-                $_customerId = $_session->getCustomer()->getId();
-            }else{
-                $_customerId = $customerId;
+                $customerId = $_session->getCustomer()->getId();
             }
             $storedCard = Mage::getModel('hps_securesubmit/storedcard');
+            $storedCard->loadByCustomerIdTokenValue($customerId, $token);
             $storedCard->setDt(Varien_Date::now())
-                ->setCustomerId($_customerId)
+                ->setCustomerId($customerId)
                 ->setTokenValue($token)
                 ->setCcType($cardType)
                 ->setCcLast4($cardData->number)
                 ->setCcExpMonth(str_pad($cardData->expMonth, 2, '0', STR_PAD_LEFT))
                 ->setCcExpYear($cardData->expYear);
             try{
-                $storedCard->removeDuplicates();
                 $storedCard->save();
                 return $storedCard;
             }catch (Exception $e){
@@ -60,5 +58,7 @@ class Hps_Securesubmit_Helper_Data extends Mage_Core_Helper_Abstract
                 Mage::throwException($e->getMessage());
             }
         }
+
+        return null;
     }
 }

--- a/app/code/community/Hps/Securesubmit/Model/Resource/Storedcard.php
+++ b/app/code/community/Hps/Securesubmit/Model/Resource/Storedcard.php
@@ -12,6 +12,36 @@ class Hps_Securesubmit_Model_Resource_Storedcard extends Mage_Core_Model_Resourc
         $this->_init('hps_securesubmit/storedcard', 'storedcard_id');
     }
 
+    /**
+     * @param Hps_Securesubmit_Model_Storedcard $object
+     * @param int $customerId
+     * @param string $tokenValue
+     * @return $this
+     */
+    public function loadByCustomerIdTokenValue(Hps_Securesubmit_Model_Storedcard $object, $customerId, $tokenValue)
+    {
+        $read = $this->_getReadAdapter();
+        if ($read && !is_null($customerId) && !is_null($tokenValue)) {
+            $select = $read->select()
+                ->from($this->getMainTable(), '*')
+                ->where('customer_id = ?', $customerId)
+                ->where('token_value = ?', $tokenValue);
+            $data = $read->fetchRow($select);
+            if ($data) {
+                $object->setData($data);
+            }
+        }
+
+        $this->unserializeFields($object);
+        $this->_afterLoad($object);
+
+        return $this;
+    }
+
+    /**
+     * @deprecated
+     * @param Hps_Securesubmit_Model_Storedcard $storedcard
+     */
     public function removeDuplicates(Hps_Securesubmit_Model_Storedcard $storedcard)
     {
         $this->_getWriteAdapter()->delete($this->getMainTable(), array(

--- a/app/code/community/Hps/Securesubmit/Model/Storedcard.php
+++ b/app/code/community/Hps/Securesubmit/Model/Storedcard.php
@@ -31,6 +31,21 @@ class Hps_Securesubmit_Model_Storedcard  extends Mage_Core_Model_Abstract
         $this->_init('hps_securesubmit/storedcard');
     }
 
+    /**
+     * @param int $customerId
+     * @param string $tokenValue
+     * @return $this
+     */
+    public function loadByCustomerIdTokenValue($customerId, $tokenValue)
+    {
+        $this->getResource()->loadByCustomerIdTokenValue($this, $customerId, $tokenValue);
+        return $this;
+    }
+
+    /**
+     * @deprecated
+     * @return $this
+     */
     public function removeDuplicates()
     {
         $this->getResource()->removeDuplicates($this);

--- a/lib/SecureSubmit/src/Services/Fluent/Gateway/Credit/HpsCreditServiceUpdateTokenExpirationBuilder.php
+++ b/lib/SecureSubmit/src/Services/Fluent/Gateway/Credit/HpsCreditServiceUpdateTokenExpirationBuilder.php
@@ -1,10 +1,10 @@
 <?php
 
-/*
- * @method HpsCreditServiceChargeBuilder withToken( $token)
-* @method HpsCreditServiceUpdateTokenExpirationBuilder withExpMonth(string $transactionId)
-* @method HpsCreditServiceUpdateTokenExpirationBuilder withExpYear(string $transactionId)
-*/
+/**
+ * @method HpsCreditServiceUpdateTokenExpirationBuilder withToken( $token)
+ * @method HpsCreditServiceUpdateTokenExpirationBuilder withExpMonth(string $transactionId)
+ * @method HpsCreditServiceUpdateTokenExpirationBuilder withExpYear(string $transactionId)
+ */
 class HpsCreditServiceUpdateTokenExpirationBuilder extends HpsBuilderAbstract
 {
 


### PR DESCRIPTION
The current code calls:

```php
 $this->_getChargeService()->updateTokenExpiration(...);
```

But the return type of `_getChargeService()` had the wrong vardocs so the return type is actually `HpsFluentCreditService` and so the `updateTokenExpiration` method takes no arguments and instead returns a `HpsCreditServiceUpdateTokenExpirationBuilder` instance. So basically the `updateTokenExpiration` call was having no effect.

This also performs the `updateTokenExpiration` **before** the charge rather than after since at this point there are many many cards that have outdated token data that cannot easily be recovered so always updating the token expiration before attempting to charge the card is the only way I see to recover these tokens that never got updated. Customers get extremely unhappy when they try over and over to charge their card and it is declined.

Lastly, this PR also updates existing `storedcard` rows rather than removing the old ones and re-inserting.